### PR TITLE
Edit Dockerfile build files acquisition to make independent from docker volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:latest
 
 WORKDIR /app
-
+COPY . .
 EXPOSE 3000
+
+RUN npm install express
+RUN npm install
 
 CMD ["node", "index.js"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,5 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    volumes:
-      - ./:/app
     ports:
       - "3000:3000"


### PR DESCRIPTION
The Dockerfile was relying on files obtained via a docker volume folder mount.

This didn't allow the correct building of the container and node module imports.

Using the COPY command fixes the issue and the volume mount is not needed anymore, furthermore the module express is installed via the Dockerfile.