### PR TITLE
Download via Blob instead of redirect

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -23,7 +23,17 @@ async function downloadFor(platform) {
     const attachments = await fetchLatestReleaseAttachments();
     const attachment = attachments.find(attachment => attachment.name.includes(platform));
 
-    window.location = attachment.downloadUrl;
+    const response = await fetch(attachment.downloadUrl, { mode: 'no-cors' });
+    const fileBlob = await response.blob();
+
+    const tmpAElement = document.createElement('a');
+    const blobUrl = URL.createObjectURL(fileBlob);
+    tmpAElement.href = blobUrl;
+    tmpAElement.setAttribute('download', attachment.name);
+    tmpAElement.setAttribute('target', '_blank');
+    tmpAElement.click();
+    URL.revokeObjectURL(blobUrl);
+    tmpAElement.remove();
 }
 
 async function populateChangelog() {

--- a/js/script.js
+++ b/js/script.js
@@ -29,8 +29,8 @@ async function downloadFor(platform) {
     const tmpAElement = document.createElement('a');
     const blobUrl = URL.createObjectURL(fileBlob);
     tmpAElement.href = blobUrl;
-    tmpAElement.setAttribute('download', attachment.name);
-    tmpAElement.setAttribute('target', '_blank');
+    tmpAElement.download = attachment.name;
+    tmpAElement.target = '_blank';
     tmpAElement.click();
     URL.revokeObjectURL(blobUrl);
     tmpAElement.remove();


### PR DESCRIPTION
On phones the redirect to *.github.com would open the GitHub app, this behaviour doesn't allow the user to download the file. Using the Blob method instead of a redirect effectively fixes this problem.